### PR TITLE
fix: allow sudo in containers by disabling no-new-privileges

### DIFF
--- a/docker-compose.alt.yml
+++ b/docker-compose.alt.yml
@@ -30,7 +30,7 @@ services:
     networks:
       - updaters
     security_opt:
-      - no-new-privileges:true
+      - no-new-privileges:false
 
   dependencies:
     image: docker-registry.markridgwell.com/credfeto/dev-dependencies:latest
@@ -60,7 +60,7 @@ services:
     networks:
       - updaters
     security_opt:
-      - no-new-privileges:true
+      - no-new-privileges:false
 
 networks:
   updaters:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     networks:
       - updaters
     security_opt:
-      - no-new-privileges:true
+      - no-new-privileges:false
 
   packages:
     image: docker-registry.markridgwell.com/credfeto/dev-packages:latest
@@ -63,7 +63,7 @@ services:
     networks:
       - updaters
     security_opt:
-      - no-new-privileges:true
+      - no-new-privileges:false
 
   cleanup:
     image: docker-registry.markridgwell.com/credfeto/dev-cleanup:latest
@@ -95,7 +95,7 @@ services:
     networks:
       - updaters
     security_opt:
-      - no-new-privileges:true
+      - no-new-privileges:false
 
   dependencies:
     image: docker-registry.markridgwell.com/credfeto/dev-dependencies:latest
@@ -125,7 +125,7 @@ services:
     networks:
       - updaters
     security_opt:
-      - no-new-privileges:true
+      - no-new-privileges:false
 
 networks:
   updaters:


### PR DESCRIPTION
no-new-privileges:true blocks sudo's setuid escalation, preventing certificate installation, dotnet setup, and home dir ownership fixes at container startup. docker-compose.minimal.yml already had false.

Fixes #20

Prompt: commit and push