### PR TITLE
fix: replicate dotnet tool-manifest path fix to all updater scripts

### DIFF
--- a/cleanup/updater
+++ b/cleanup/updater
@@ -134,7 +134,7 @@ while sleep 120; do
   {
     info "Installing tools..."
     date
-    [ ! -d ./.config ] && [ ! -f "$HOME/.config/dotnet-tools.json" ] && "$DOTNET_ROOT/dotnet" new tool-manifest
+    [ ! -f "$HOME/dotnet-tools.json" ] && "$DOTNET_ROOT/dotnet" new tool-manifest
     info "Installing Credfeto.DotNet.Repo.Tools.Cmd"
     "$DOTNET_ROOT/dotnet" tool install --local Credfeto.DotNet.Repo.Tools.Cmd
     "$DOTNET_ROOT/dotnet" tool update --local Credfeto.DotNet.Repo.Tools.Cmd

--- a/dependencies/updater
+++ b/dependencies/updater
@@ -121,7 +121,7 @@ while sleep 120; do
   {
     info "Installing tools..."
     date
-    [ ! -d ./.config ] && [ ! -f "$HOME/.config/dotnet-tools.json" ] && "$DOTNET_ROOT/dotnet" new tool-manifest
+    [ ! -f "$HOME/dotnet-tools.json" ] && "$DOTNET_ROOT/dotnet" new tool-manifest
     info "Installing Credfeto.DotNet.Repo.Tools.Cmd"
     "$DOTNET_ROOT/dotnet" tool install --local Credfeto.DotNet.Repo.Tools.Cmd
     "$DOTNET_ROOT/dotnet" tool update --local Credfeto.DotNet.Repo.Tools.Cmd

--- a/packages/updater
+++ b/packages/updater
@@ -127,7 +127,7 @@ while sleep 120; do
   {
     info "Installing Credfeto.DotNet.Repo.Tools.Cmd"
     date
-    [ ! -d ./.config ] && [ ! -f "$HOME/.config/dotnet-tools.json" ] && "$DOTNET_ROOT/dotnet" new tool-manifest
+    [ ! -f "$HOME/dotnet-tools.json" ] && "$DOTNET_ROOT/dotnet" new tool-manifest
     "$DOTNET_ROOT/dotnet" tool install --local Credfeto.DotNet.Repo.Tools.Cmd
     "$DOTNET_ROOT/dotnet" tool update --local Credfeto.DotNet.Repo.Tools.Cmd
     "$DOTNET_ROOT/dotnet" tool list


### PR DESCRIPTION
Closes #33

Prompt: `[ ! -f "$HOME/dotnet-tools.json" ] && "$DOTNET_ROOT/dotnet" new tool-manifest` change needed replicating too